### PR TITLE
chore: remove unneeded find_library in CMakeLists.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 project(sandbox)
 cmake_minimum_required(VERSION 3.0)
 
-find_library(STDCPPFS_LIBRARY stdc++fs)
 find_package(fmt)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -22,4 +21,4 @@ execute_process(
 string(REPLACE "\n" "" NODE_ADDON_API_DIR ${NODE_ADDON_API_DIR})
 string(REPLACE "\"" "" NODE_ADDON_API_DIR ${NODE_ADDON_API_DIR})
 target_include_directories(${PROJECT_NAME} PRIVATE ${NODE_ADDON_API_DIR})
-target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB} ${STDCPPFS_LIBRARY} fmt::fmt)
+target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB} fmt::fmt)


### PR DESCRIPTION
见 #19 .