### PR TITLE
Fix incompatibility with libfmt v9

### DIFF
--- a/native/utils.h
+++ b/native/utils.h
@@ -5,6 +5,15 @@
 #include <stdexcept>
 #include <system_error>
 
+#if FMT_VERSION >= 90000
+
+#include <filesystem>
+#include <fmt/ostream.h>
+
+template <> struct fmt::formatter<std::filesystem::path> : fmt::ostream_formatter {};
+
+#endif
+
 std::string SignalToString(int signal);
 
 void Ensure_Seccomp(int XX);


### PR DESCRIPTION
使用最新版 fmt 时，该项目无法编译通过。
参考链接：https://github.com/fmtlib/fmt/issues/3112
我按照 fmt 文档的提示，做了一些修补。